### PR TITLE
feat: implementera endpoint för volontäranmälan till mission (POST /m…

### DIFF
--- a/backend/Application/DTOs/AssignMissionDto.cs
+++ b/backend/Application/DTOs/AssignMissionDto.cs
@@ -1,0 +1,7 @@
+namespace Application.DTOs
+{
+    public class AssignMissionDto
+    {
+        public Guid MissionId { get; set; }
+    }
+}

--- a/backend/Application/Interfaces/IMissionService.cs
+++ b/backend/Application/Interfaces/IMissionService.cs
@@ -7,6 +7,6 @@ namespace Application.Interfaces
     {
         Task<IEnumerable<MissionDto>> GetMissionsByOrganizationIdAsync(Guid organizationId, MissionStatus? status = null);
         Task<Guid> CreateMissionAsync(CreateMissionDto dto, Guid organizationId);
-        Task<bool> AssignVolunteerToMissionAsync(Guid missionId, Guid volunteerId);
+        Task<AssignResult> AssignVolunteerToMissionAsync(Guid missionId, Guid volunteerId);
     }
 }

--- a/backend/Domain/Enums/AssignResult.cs
+++ b/backend/Domain/Enums/AssignResult.cs
@@ -1,0 +1,11 @@
+namespace Domain.Enums
+{
+    public enum AssignResult
+    {
+        Success,
+        AlreadyAssigned,
+        MissionNotFound,
+        VolunteerNotFound,
+        Error
+    }
+}


### PR DESCRIPTION
…issions/{id}/assign)

Lagt till ny endpoint i MissionsController som låter en inloggad volontär anmäla sig till ett mission via ID i URL.

Använder AssignResult-enum för tydlig felhantering (AlreadyAssigned, MissionNotFound, etc).

Returnerar rätt HTTP-status beroende på scenario (200, 409, 404, 401, 500).

Temporär testversion borttagen – endpoint kräver nu giltiga JWT-claims (volunteerId).